### PR TITLE
change Span::linecol_in to index lines from 1

### DIFF
--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -15,15 +15,17 @@ impl Span {
     pub fn linecol_in(&self, text: &str) -> (usize, usize) {
         let mut cur = 0;
         // Use split_terminator instead of lines so that if there is a `\r`,
-        // it is included in the offset calculation. The `+1` values below
-        // account for the `\n`.
+        // it is included in the offset calculation. The `+1` values on columns
+        // below account for the `\n`.
+        // The +1 on lines accounts for line numbers are traditional 1-indexed,
+        // whereas enumerate is 0-indexed.
         for (i, line) in text.split_terminator('\n').enumerate() {
             if cur + line.len() + 1 > self.offset {
-                return (i, self.offset - cur);
+                return (i + 1, self.offset - cur);
             }
             cur += line.len() + 1;
         }
-        (text.lines().count(), 0)
+        (text.lines().count() + 1, 0)
     }
 }
 

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -198,7 +198,7 @@ impl fmt::Display for Error {
       | {marker:>0$}",
             text.col + 1,
             file = file,
-            line = text.line + 1,
+            line = text.line,
             col = text.col + 1,
             err = err,
             text = text.snippet,
@@ -212,7 +212,9 @@ impl std::error::Error for Error {}
 impl Text {
     fn new(content: &str, span: Span) -> Text {
         let (line, col) = span.linecol_in(content);
-        let snippet = content.lines().nth(line).unwrap_or("").to_string();
+        // nth(line - 1) because linecol_in returns 1-indexed lines (like text editors expect) but
+        // lines().nth() is 0-indexed (like programmers expect)
+        let snippet = content.lines().nth(line - 1).unwrap_or("").to_string();
         Text { line, col, snippet }
     }
 }


### PR DESCRIPTION
When we consume `Span::linecol_in` in witx, we assumed that lines were 1-indexed, when instead they were 0-indexed.

Previously, lines were adjusted to be 1-indexed only when printing the line number in the `Display` impl for `Error`. Text editors expect lines to be 1-indexed, so this is correct to display to a user.

This PR changes the output of linecol_in to 1-indexed lines, and the places that consume it to expect that.

This is fairly subjective, so I totally understand if you want to leave wast the way it is and have me fix witx instead.